### PR TITLE
Add support for tmux-256color

### DIFF
--- a/color_test.go
+++ b/color_test.go
@@ -638,6 +638,11 @@ func TestOther(t *testing.T) {
 	})
 
 	// TERM
+	mockEnvValue("TERM", "tmux-256color", func(_ string) {
+		is.True(IsSupportColor())
+	})
+
+	// TERM
 	mockEnvValue("TERM", "rxvt-unicode-256color", func(_ string) {
 		is.True(IsSupportColor())
 	})

--- a/utils.go
+++ b/utils.go
@@ -12,11 +12,13 @@ import (
 // 	"TERM=xterm-vt220"
 // 	"TERM=xterm-256color"
 // 	"TERM=screen-256color"
+// 	"TERM=tmux-256color"
 // 	"TERM=rxvt-unicode-256color"
 // Don't support color:
 // 	"TERM=cygwin"
 var specialColorTerms = map[string]bool{
 	"screen-256color":       true,
+	"tmux-256color":         true,
 	"rxvt-unicode-256color": true,
 }
 
@@ -74,6 +76,7 @@ func IsSupportColor() bool {
 func IsSupport256Color() bool {
 	// "TERM=xterm-256color"
 	// "TERM=screen-256color"
+	// "TERM=tmux-256color"
 	// "TERM=rxvt-unicode-256color"
 	return strings.Contains(os.Getenv("TERM"), "256color")
 }


### PR DESCRIPTION
The recommended way of enabling color support in tmux is to set the
terminal to `screen-256color` or `tmux-256color`: https://github.com/tmux/tmux/wiki/FAQ