### PR TITLE
Add Lprint function

### DIFF
--- a/tag.go
+++ b/tag.go
@@ -3,9 +3,9 @@ package color
 import (
 	"fmt"
 	"io"
+	"log"
 	"regexp"
 	"strings"
-	"log"
 )
 
 // output colored text like use html tag. (not support windows cmd)
@@ -168,13 +168,13 @@ func Fprintln(w io.Writer, a ...interface{}) {
 // Lprint passes colored messages to a log.Logger for printing.
 // Notice: should be goroutine safe
 func Lprint(l *log.Logger, a ...interface{}) {
-    if isLikeInCmd {
-        renderColorCodeOnCmd(func() {
-            l.Print(Render(a...))
-        })
-    } else {
-        l.Print(Render(a...))
-    }
+	if isLikeInCmd {
+		renderColorCodeOnCmd(func() {
+			l.Print(Render(a...))
+		})
+	} else {
+		l.Print(Render(a...))
+	}
 }
 
 // Render parse color tags, return rendered string.

--- a/tag.go
+++ b/tag.go
@@ -165,7 +165,7 @@ func Fprintln(w io.Writer, a ...interface{}) {
 	}
 }
 
-// Print colored messages to a log.Logger.
+// Lprint passes colored messages to a log.Logger for printing.
 // Notice: should be goroutine safe
 func Lprint(l *log.Logger, a ...interface{}) {
     if isLikeInCmd {

--- a/tag.go
+++ b/tag.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"regexp"
 	"strings"
+	"log"
 )
 
 // output colored text like use html tag. (not support windows cmd)
@@ -162,6 +163,18 @@ func Fprintln(w io.Writer, a ...interface{}) {
 	} else {
 		_, _ = fmt.Fprintln(w, ReplaceTag(str))
 	}
+}
+
+// Print colored messages to a log.Logger.
+// Notice: should be goroutine safe
+func Lprint(l *log.Logger, a ...interface{}) {
+    if isLikeInCmd {
+        renderColorCodeOnCmd(func() {
+            l.Print(Render(a...))
+        })
+    } else {
+        l.Print(Render(a...))
+    }
 }
 
 // Render parse color tags, return rendered string.

--- a/tag_test.go
+++ b/tag_test.go
@@ -2,7 +2,7 @@ package color
 
 import (
 	"testing"
-
+	"log"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -31,7 +31,7 @@ func TestReplaceTag(t *testing.T) {
 	is.NotContains(r, ">")
 
 	// sample 3
-	s = `abc <err>err-text</> 
+	s = `abc <err>err-text</>
 def <info>info text
 </>`
 	r = ReplaceTag(s)
@@ -135,6 +135,12 @@ func TestPrint(t *testing.T) {
 	Fprintf(buf, "<red>%s</>", "MSG")
 	is.Equal("\x1b[0;31mMSG\x1b[0m", buf.String())
 	buf.Reset()
+
+	// Lprint
+	logger := log.New(buf, "", 0)
+	Lprint(logger, "<red>MSG</>\n")
+	is.Equal("\x1b[0;31mMSG\x1b[0m\n", buf.String())
+	buf.Reset()
 }
 
 func TestWrapTag(t *testing.T) {
@@ -157,7 +163,7 @@ func TestClearTag(t *testing.T) {
 	is.Equal("text", ClearTag("<err>text</>"))
 	is.Equal("abc error def info text", ClearTag("abc <err>error</> def <info>info text</>"))
 
-	str := `abc <err>err-text</> 
+	str := `abc <err>err-text</>
 def <info>info text
 </>`
 	ret := ClearTag(str)


### PR DESCRIPTION
This function can be passed a log.Logger, which is goroutine-safe as indicated [here](https://golang.org/pkg/log/#Logger).