### PR TITLE
Fix invalid pointer in stack when stack grows

### DIFF
--- a/color_windows.go
+++ b/color_windows.go
@@ -157,7 +157,7 @@ func EnableVirtualTerminalProcessing(stream syscall.Handle, enable bool) error {
 		mode &^= EnableVirtualTerminalProcessingMode
 	}
 
-	ret, _, err := procSetConsoleMode.Call(uintptr(unsafe.Pointer(stream)), uintptr(mode))
+	ret, _, err := procSetConsoleMode.Call(uintptr(stream), uintptr(mode))
 	if ret == 0 {
 		return err
 	}


### PR DESCRIPTION
Hi,

Starting from Go 1.14.x (if I'm right), unsafe and dll calls changed a bit in the way pointers should be passed.

To reproduce the issue launch a go routine from main and try to output a colorized text.

This is a Windows specific bug.

Regards,
Mauro.