### PR TITLE
fix: fix slice init length

### DIFF
--- a/convert.go
+++ b/convert.go
@@ -479,7 +479,7 @@ func Rgb2hex(rgb []int) string { return RgbToHex(rgb) }
 //
 //	hex := RgbToHex([]int{170, 187, 204}) // hex: "aabbcc"
 func RgbToHex(rgb []int) string {
-	hexNodes := make([]string, len(rgb))
+	hexNodes := make([]string, 0, len(rgb))
 
 	for _, v := range rgb {
 		hexNodes = append(hexNodes, strconv.FormatInt(int64(v), 16))


### PR DESCRIPTION
The intention here should be to initialize a slice with a capacity of len(rgb) rather than initializing the length of this slice. 

The online demo: https://go.dev/play/p/q1BcVCmvidW