### PR TITLE
fix: resolve color tag parsing issue in #52

### DIFF
--- a/color_tag.go
+++ b/color_tag.go
@@ -347,7 +347,7 @@ func (tp *TagParser) Parse(str string) string {
 
 	// item: 0 full text 1 tag name 2 tag content
 	for _, item := range matched {
-		full, tag, body := item[0], item[1], item[2]
+		full, tag, body := repairMatchedTag(item[0], item[1], item[2])
 
 		// use defined color tag name: "<info>content</>" -> tag: "info"
 		if !strings.ContainsRune(tag, '=') {
@@ -369,6 +369,19 @@ func (tp *TagParser) Parse(str string) string {
 	}
 
 	return str
+}
+
+func repairMatchedTag(full, tag, body string) (string, string, string) {
+	if len(colorTags[tag]) == 0 && len(namedRgbMap[tag]) == 0 && len(ParseCodeFromAttr(tag)) == 0 {
+		if matched := matchRegex.FindAllStringSubmatch(strings.TrimPrefix(full, "<"+tag+">"), -1); len(matched) > 0 {
+			full = matched[0][0]
+			tag = matched[0][1]
+			body = matched[0][2]
+			return repairMatchedTag(full, tag, body)
+		}
+	}
+
+	return full, tag, body
 }
 
 // ReplaceTag parse string, replace color tag and return rendered string


### PR DESCRIPTION
This PR addresses the color tag parsing issue by introducing a `repairMatchedTag` function. The function recursively handles invalid or malformed color tags and attempts to repair them by re-parsing the tag content. This ensures more robust parsing of color tags, especially for nested or malformed tags.

```go
package main

import (
	"fmt"
	"github.com/gookit/color"
)

func main() {
	test1 := `
one <bg=lightGreen;fg=black>two</> <three>
foo <bg=lightGreen;fg=black>two</> <four>

`

	test2 := `
 foo <bg=lightGreen;fg=black>
two
</>
`

	test3 := `
<yes>
	<a=b;>
		<fg=red>hello</>
		<fg=yellow>OK</>
	</>
</>
`
	fmt.Println()
	color.Println(test1)
	color.Println(test2)
	color.Println(test3)
}

```

<img width="562" alt="image" src="https://github.com/user-attachments/assets/db21b359-2472-4dc5-83a1-711f22dda5bf" />
