### PR TITLE
fix: re-apply color after nested reset in RenderString

### DIFF
--- a/color.go
+++ b/color.go
@@ -227,8 +227,13 @@ func RenderString(code string, str string) string {
 		return ClearCode(str)
 	}
 
-	// return fmt.Sprintf(FullColorTpl, code, str)
-	return StartSet + code + "m" + str + ResetSet
+	open := StartSet + code + "m"
+	// If the string contains reset sequences, re-apply our color after each
+	// reset so that nested colored args don't break the outer color.
+	if strings.Contains(str, ResetSet) {
+		str = strings.ReplaceAll(str, ResetSet, ResetSet+open)
+	}
+	return open + str + ResetSet
 }
 
 // ClearCode clear color codes.


### PR DESCRIPTION
Fixes #67

## Problem

When using `Printf` with a pre-colored string argument, the inner color's reset sequence (`\033[0m`) terminates the outer color, leaving the rest of the string uncolored:

```go
green := color.Green.Sprint("green")
color.Red.Printf("before %s after", green)
// "after" appears uncolored instead of red
```

**Before (broken):**
```
\033[31mbefore \033[32mgreen\033[0m after\033[0m
                                    ^^^^^ not red!
```

## Fix

In `RenderString`, detect any reset sequences within the string and re-apply the current color code after each reset:

**After (fixed):**
```
\033[31mbefore \033[32mgreen\033[0m\033[31m after\033[0m
                                   ^^^^^^^^^ red restored!
```

This is a common technique used by other color libraries (e.g., chalk in Node.js). All existing tests pass.